### PR TITLE
Ticket7697

### DIFF
--- a/eurotherm2kApp/protocol/eurotherm2k.proto
+++ b/eurotherm2kApp/protocol/eurotherm2k.proto
@@ -2,10 +2,10 @@
 ## Stream Device Protocol for eurotherm 2000 series EI Bisynch
 ## will look for the record \$1ERR which will process any errors
 
-locktimeout = 5000;
+locktimeout = 10000;
 
 # Uses a timeout when there is no termination character (i.e. for reads)
-replytimeout = 200;
+replytimeout = 2000;
 readtimeout  = 100;
 extrainput   = Error;
 

--- a/eurotherm2kApp/protocol/eurotherm2k.proto
+++ b/eurotherm2kApp/protocol/eurotherm2k.proto
@@ -7,6 +7,7 @@ locktimeout = 10000;
 # Uses a timeout when there is no termination character (i.e. for reads)
 replytimeout = 2000;
 readtimeout  = 100;
+PollPeriod   = 200;
 extrainput   = Error;
 
 # time to wait after read (see below)


### PR DESCRIPTION
https://github.com/ISISComputingGroup/IBEX/issues/7697

Added explicit `PollPeriod` as, by default, `PollPeriod` is equal to `replytimeout`.

Task to test changes on real device: https://github.com/ISISComputingGroup/IBEX/projects/8#card-89110813